### PR TITLE
Move pluralize class outside of the twig runtime

### DIFF
--- a/Tests/PluralizeTest.php
+++ b/Tests/PluralizeTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Bytes\PluralizeBundle\Tests;
+
+use Bytes\PluralizeBundle\Pluralize;
+use PHPUnit\Framework\TestCase;
+
+class PluralizeTest extends TestCase
+{
+
+    /**
+     * @dataProvider provideValues
+     * @param $number
+     * @param $string
+     * @param $expected
+     */
+    public function testGetPluralizedString($number, $string, $expectedFull, $expected)
+    {
+        $results = Pluralize::pluralize($number, $string, false);
+        $this->assertEquals($expected, $results);
+
+        $results = Pluralize::pluralize($number, $string, true);
+        $this->assertEquals($expectedFull, $results);
+    }
+
+    public function provideValues()
+    {
+        yield['number' => 0, 'string' => 'word', 'expectedFull' => '0 words', 'expected' => 'words'];
+        yield['number' => 1, 'string' => 'word', 'expectedFull' => '1 word', 'expected' => 'word'];
+        yield['number' => 2, 'string' => 'word', 'expectedFull' => '2 words', 'expected' => 'words'];
+    }
+}

--- a/src/Pluralize.php
+++ b/src/Pluralize.php
@@ -1,0 +1,50 @@
+<?php
+
+
+namespace Bytes\PluralizeBundle;
+
+
+use Illuminate\Support\Str;
+use function Symfony\Component\String\u;
+
+/**
+ * Class Pluralize
+ * @package Bytes\PluralizeBundle
+ */
+class Pluralize
+{
+    /**
+     * Get a plural variation of a string
+     *
+     * @param integer $number
+     * @param string $string
+     * @param bool $includeNumber
+     *
+     * @return string
+     */
+    public static function pluralize(int $number, string $string, bool $includeNumber = true)
+    {
+        // Choose the correct string
+        if ($number == 1) {
+            return self::format($number, Str::singular($string), $includeNumber);
+        } else {
+            return self::format($number, Str::plural($string), $includeNumber);
+        }
+    }
+
+    /**
+     * @param int $number
+     * @param string $string
+     * @param bool $includeNumber
+     * @return string
+     */
+    private static function format(int $number, string $string, bool $includeNumber = false): string
+    {
+        if($includeNumber)
+        {
+            return u($string)->prepend(' ')->prepend($number)->toString();
+        } else {
+            return $string;
+        }
+    }
+}

--- a/src/Twig/AppRuntime.php
+++ b/src/Twig/AppRuntime.php
@@ -3,8 +3,8 @@
 
 namespace Bytes\PluralizeBundle\Twig;
 
+use Bytes\PluralizeBundle\Pluralize;
 use Exception;
-use Illuminate\Support\Str;
 use Twig\Extension\RuntimeExtensionInterface;
 
 /**
@@ -27,14 +27,11 @@ class AppRuntime implements RuntimeExtensionInterface
     {
         // Is it a number?
         if (!is_numeric($number)) {
-            throw new Exception('$value must be a number.');
+            throw new Exception('$number must be a number.');
         }
-
-        // Choose the correct string
-        if ($number == 1) {
-            return Str::singular($string);
-        } else {
-            return Str::plural($string);
+        if(!is_string($string)) {
+            throw new Exception('$string must be a string.');
         }
+        return Pluralize::pluralize($number, $string, false);
     }
 }


### PR DESCRIPTION
Move pluralize class outside of the twig runtime to let this more easily be used outside of Twig